### PR TITLE
Add Heidelberg to weather report

### DIFF
--- a/eduzen_bot/plugins/commands/btc/command.py
+++ b/eduzen_bot/plugins/commands/btc/command.py
@@ -45,6 +45,7 @@ def get_crypto_report():
 
     clima = get_klima("buenos aires").replace("By api.openweathermap.org", "")
     amsterdam = get_klima("amsterdam").replace("By api.openweathermap.org", "")
+    heidelberg = get_klima("heidelberg,de").replace("By api.openweathermap.org", "")
 
     text = "\n".join([dog, eth, btc])
     import datetime  # noqa
@@ -54,6 +55,7 @@ def get_crypto_report():
         f"Buenas buenas hoy es {hoy}:\n\n"
         f"{clima}"
         f"{amsterdam}"
+        f"{heidelberg}"
         "\nel blue:\n"
         f"{blue}\n"
         "el oficial:\n"

--- a/eduzen_bot/plugins/commands/weather/api.py
+++ b/eduzen_bot/plugins/commands/weather/api.py
@@ -35,7 +35,7 @@ def get_klima(city_name="München"):
         return msg
 
     msg = (
-        f"*Clima in {city_name}*\n"
+        f"*Clima en {data['name']}*\n"
         f"Temp {data['main']['temp']} °C probabilidades de lluvia {data['main']['humidity']}%\n"
         f"Max {data['main']['temp_max']} °C\n"
         f"Min {data['main']['temp_min']} °C\n"


### PR DESCRIPTION
Adding Heidelberg to the weather report.
Also, use the city name provided from the openweathermap API instead of the city name used to query the API.